### PR TITLE
remove root user dependencies from voltdb.clj 

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,15 +4,14 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.11.1"]
-                 [jepsen "0.3.3"]
+                 ; we can't upgrade to '0.3.5' otherwise you get a java.util.SequencedCollection error, see https://aphyr.com/posts/369-classnotfoundexception-java-util-sequencedcollection
+                 [jepsen "0.3.4"]
                  [org.clojure/data.xml "0.0.8"]
-                 [org.voltdb/voltdbclient "12.1.0"]
+
+                 [org.voltdb/voltdbclient "13.3.2"]
                  ; VoltDB seems to depend on Netty classes but doesn't declare
                  ; a dependency on it?
                  [io.netty/netty-all "4.1.94.Final"]
-                 ; Might need these too?
-                 ;[io.netty/netty-tcnative-boringssl-static "2.0.56.Final"]
-                 ;[io.netty/netty-tcnative-classes "2.0.56.Final"]
                  [org.clojure/data.csv "1.0.1"]
                  ]
   :jvm-opts ["-Xmx8g"

--- a/src/jepsen/voltdb.clj
+++ b/src/jepsen/voltdb.clj
@@ -130,8 +130,8 @@
                       init-schema-file "init-schema"]
                   (cu/write-file! init-schema init-schema-file)
                   (c/exec (c/env {"JAVA_HOME" (System/getenv "JAVA_HOME")
-                                  "PATH" (System/getenv "PATH")})
-                          (str  base-dir "/bin/voltdb")
+                                  })
+                          "bin/voltdb"
                           :init
                           :-s init-schema-file
                           :--config (str base-dir "/deployment.xml")
@@ -201,7 +201,7 @@
                                    :logfile (str base-dir "/log/stdout.log")
                                    :pidfile pidfile
                                    :chdir   base-dir}
-                                  (str base-dir "/bin/voltdb")
+                                  "bin/voltdb"
                                   :start
                                   :--count (count (:nodes test))
                                   :--host (->> (:nodes test)
@@ -235,7 +235,7 @@
   [query]
   (c/cd base-dir
       (c/exec (c/env {"JAVA_HOME" (System/getenv "JAVA_HOME")
-                      "PATH" (System/getenv "PATH")})
+                      })
                       "bin/sqlcmd" (str "--query=" query))))
 
 (defn snarf-procedure-deps!
@@ -257,7 +257,7 @@
   ; Volt currently plans on JDK8, and we're concerned that running on 17 might
   ; be the cause of a bug. Just in case, we'll target compilation back to 11
   ; (the oldest version you can install on Debian Bookworm easily)
-  (let [r (sh "bash" "-c" (str "JAVA_HOME=" (System/getenv "JAVA_HOME")) " javac -source 8 -target 8 -classpath \"./:./*\" -d ./obj *.java"
+  (let [r (sh "bash" "-c" (str (System/getenv "JAVA_HOME") "/bin/javac -verbose -source 8 -target 8 -classpath \"./:./*\" -d ./obj *.java")
               :dir "procedures/")]
     (when-not (zero? (:exit r))
       (throw (RuntimeException. (str "STDOUT:\n" (:out r)

--- a/src/jepsen/voltdb.clj
+++ b/src/jepsen/voltdb.clj
@@ -39,7 +39,6 @@
 (def export-csv-dir "export")
 (def export-csv-files "export")
 (def pidfile (str base-dir "/pidfile"))
-(def java_home "/opt/oracle_java17")
 
 (defn list-export-files
   "List export files for the export tests"
@@ -198,7 +197,7 @@
   [test]
           (c/cd base-dir
                 (info "Starting voltdb")
-                (cu/start-daemon! {:env {:JAVA_HOME java_home }
+                (cu/start-daemon! {:env {:JAVA_HOME (System/getenv "JAVA_HOME") }
                                    :logfile (str base-dir "/log/stdout.log")
                                    :pidfile pidfile
                                    :chdir   base-dir}

--- a/src/jepsen/voltdb.clj
+++ b/src/jepsen/voltdb.clj
@@ -55,11 +55,11 @@
   (reify os/OS
     (setup! [_ test node]
       (os/setup! os test node)
-      (comment these should already be installed and in the path
-      (debian/install ["python3" "openjdk-17-jdk-headless"])
-      (c/exec :update-alternatives :--install "/usr/bin/python" "python"
-              "/usr/bin/python3" 1))
-      )
+      ;these should already be installed and in the pat
+      ;(debian/install ["python3" "openjdk-17-jdk-headless"])
+      ;(c/exec :update-alternatives :--install "/usr/bin/python" "python"
+      ;        "/usr/bin/python3" 1))
+      ;)
 
     (teardown! [_ test node]
       (os/teardown! os test node))))
@@ -146,7 +146,7 @@
                 (c/upload (:license test) (str base-dir "/license.xml"))
                 (cu/write-file! (deployment-xml test) "deployment.xml")
                 (init-db! node)
-                (comment this is needed for compatibility between older versions that create a voltdbroot dir )
+                ; this is so jepsen can find the log in a standard place )
                 (c/exec :mkdir :-p "log")
                 (c/exec :ln :-f :-s (str base-dir "/voltdbroot/log/volt.log") (str base-dir "/log/volt.log"))))
 

--- a/src/jepsen/voltdb.clj
+++ b/src/jepsen/voltdb.clj
@@ -130,8 +130,14 @@
                                  );"
                       init-schema-file "init-schema"]
                   (cu/write-file! init-schema init-schema-file)
-                  (c/exec* (str "JAVA_HOME=" java_home " bin/voltdb init --schema " init-schema-file " --config " base-dir "/deployment.xml --dir " base-dir " --force"
-                          ))))
+                  (c/exec (c/env {"JAVA_HOME" (System/getenv "JAVA_HOME")
+                                  "PATH" (System/getenv "PATH")})
+                          (str  base-dir "/bin/voltdb")
+                          :init
+                          :-s init-schema-file
+                          :--config (str base-dir "/deployment.xml")
+                          ;| :tee (str base-dir "/log/stdout.log")
+                          )))
   (info node "initialized"))
 
 (defn configure!
@@ -228,7 +234,9 @@
   "Takes an SQL query and runs it on the local node via sqlcmd"
   [query]
   (c/cd base-dir
-                (c/exec* (str "JAVA_HOME=" java_home " bin/sqlcmd --query=\"" query "\""))))
+      (c/exec (c/env {"JAVA_HOME" (System/getenv "JAVA_HOME")
+                      "PATH" (System/getenv "PATH")})
+                      "bin/sqlcmd" (str "--query=" query))))
 
 (defn snarf-procedure-deps!
   "Downloads voltdb.jar from the current node to procedures/, so we can compile

--- a/src/jepsen/voltdb.clj
+++ b/src/jepsen/voltdb.clj
@@ -55,11 +55,11 @@
   (reify os/OS
     (setup! [_ test node]
       (os/setup! os test node)
-      ;these should already be installed and in the pat
+      ;(comment these should already be installed and in the path
       ;(debian/install ["python3" "openjdk-17-jdk-headless"])
       ;(c/exec :update-alternatives :--install "/usr/bin/python" "python"
       ;        "/usr/bin/python3" 1))
-      ;)
+      )
 
     (teardown! [_ test node]
       (os/teardown! os test node))))
@@ -146,7 +146,7 @@
                 (c/upload (:license test) (str base-dir "/license.xml"))
                 (cu/write-file! (deployment-xml test) "deployment.xml")
                 (init-db! node)
-                ; this is so jepsen can find the log in a standard place )
+                ; this is so jepsen can find the log in a standard place
                 (c/exec :mkdir :-p "log")
                 (c/exec :ln :-f :-s (str base-dir "/voltdbroot/log/volt.log") (str base-dir "/log/volt.log"))))
 

--- a/src/jepsen/voltdb.clj
+++ b/src/jepsen/voltdb.clj
@@ -135,13 +135,9 @@
                                  );"
                       init-schema-file "init-schema"]
                   (cu/write-file! init-schema init-schema-file)
-                  (c/exec (str "JAVA_HOME=/opt/oracle_java17 PATH=/opt/oracle_java17/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin " base-dir "/bin/voltdb")
-                          :init
-                          :-s init-schema-file
-                          :--config (str base-dir "/deployment.xml")
-                          :--dir base-dir
-                          :--force
-                          | :tee (str base-dir "/log/init-stdout.log"))))
+                  (c/exec* (str "JAVA_HOME=/opt/oracle_java17 PATH=/opt/oracle_java17/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin bin/voltdb"
+                          " init -s " init-schema-file " --config " base-dir "/deployment.xml --dir " base-dir " --force"
+                          ))))
   (info node "initialized"))
 
 (defn configure!
@@ -238,7 +234,7 @@
   "Takes an SQL query and runs it on the local node via sqlcmd"
   [query]
   (c/cd base-dir
-                (c/exec "bin/sqlcmd" (str "--query=" query))))
+                (c/exec* (str "JAVA_HOME=/opt/oracle_java17 bin/sqlcmd --query=\"" query "\""))))
 
 (defn snarf-procedure-deps!
   "Downloads voltdb.jar from the current node to procedures/, so we can compile


### PR DESCRIPTION
don't sudo when we don't need to, keep it simple, it should run as the user that started it.