### PR TITLE
ENG-29692: jepsen export workload -- read the final db-read from a live node

### DIFF
--- a/src/jepsen/voltdb/export.clj
+++ b/src/jepsen/voltdb/export.clj
@@ -133,6 +133,43 @@
   (wait-export-pending conn)
   (into [] (flatten (map  download-parse-export! (:nodes test)))))
 
+(defn db-read-values
+  "Reads all values from table-name using the supplied connection."
+  [conn table-name]
+  (->> (vc/ad-hoc! conn (str "SELECT value FROM " table-name " ORDER BY value;"))
+       first
+       :rows
+       (map :VALUE)))
+
+(defn db-read-live
+  "Reads all values from table-name against a node that is currently alive.
+
+  The per-worker client (jepsen.voltdb.client/connect) is deliberately NOT
+  topology-change aware, so it is pinned to a single node. When VoltDB's own
+  partition detection shuts that node down during the run, the pinned
+  connection returns nothing and the final consistency read spuriously reports
+  every committed write as lost. We therefore discover which nodes are still
+  alive and read from the first one that answers, so the final read reflects
+  the surviving cluster rather than a dead node."
+  [test table-name]
+  (let [live (vc/up-nodes test)]
+    (when (empty? live)
+      (throw (IllegalStateException. "No live VoltDB nodes available for db-read")))
+    (loop [[node & more] live]
+      (let [result (try
+                     {:ok (let [conn (vc/connect node test)]
+                            (try
+                              (doall (db-read-values conn table-name))
+                              (finally (vc/close! conn))))}
+                     (catch Exception e
+                       (warn e "db-read against" node "failed")
+                       {:error e}))]
+        (if (contains? result :ok)
+          (:ok result)
+          (if (seq more)
+            (recur more)
+            (throw (:error result))))))))
+
 (defrecord Client [table-name     ; The name of the table we write to
                    stream-name    ; The name of the stream we write to
                    target-name    ; The name of our export target
@@ -190,12 +227,10 @@
                              (rand-int 1000)
                              (long-array (:value op)))
                    (assoc op :type :ok))
-        ; Read all data from the table '(table-name)
-        :db-read (let [v (->>
-                          (vc/ad-hoc! conn (str "SELECT value FROM " table-name " ORDER BY value;"))
-                               first
-                               :rows
-                               (map :VALUE))]
+        ; Read all data from the table '(table-name). We read from a live node
+        ; rather than the pinned `conn`, which may have been shut down by
+        ; partition detection during the run (see db-read-live).
+        :db-read (let [v (db-read-live test table-name)]
                      (assoc op :type :ok :value v))
         ; Read all exported data from cvs file
         :export-read (let [v (export-data! test conn)]


### PR DESCRIPTION
Problem
The export workload's final consistency read (:db-read) runs its SELECT on the per-worker client connection. That client is created by jepsen.voltdb.client/connect, which deliberately sets .setTopologyChangeAware false ("We don't want to try and connect to all nodes"), so every worker is pinned to exactly one node.

Under the partition nemesis on a partition-detection-enabled cluster, VoltDB itself shuts down the isolated minority node, and a partition-detected node does not auto-rejoin. Because the nemesis only cuts/heals the network (it never restarts a process), isolating a distinct node each round drains the cluster monotonically (5 -> 4 -> 3 -> 2 survivors). If the worker that runs the final :db-read was pinned to one of the killed nodes, the read fails with Connection refused and returns zero rows.

The checker then compares the client-acknowledged writes against that empty db-read and flags every committed write as lost and every export row as phantom -- a false consistency failure, even though the surviving nodes (with kfactor >= 1) still hold a full, correct copy of the data.

Observed on a 5-node k=4 run of -w export --nemesis partition (VoltDB Ent 13.3.16): survivors fc2/fc6 were healthy and export read back all 68,776 committed rows, yet the run reported:

:db-read-count            0
:lost-transaction-count   68584   (== client-ok-count)
:phantom-export-count     68776   (== export-read-count)
:valid?                   false
Both failure numbers being exactly their totals is the fingerprint of a comparison against an empty db-read, not of an actual partial loss.

Fix
In src/jepsen/voltdb/export.clj, make the final :db-read read from a node that is actually alive instead of the pinned worker connection.

New helper db-read-values -- extracts the SELECT value FROM <table> read given a connection (the previous inline query body).
New helper db-read-live -- discovers live nodes via the existing jepsen.voltdb.client/up-nodes, opens a fresh connection to the first one that answers, reads the table, and falls through to the next live node on error. If no node is alive it throws, so gen/until-ok keeps retrying rather than silently accepting a zero-row read.
The :db-read branch of invoke! now calls db-read-live instead of running the ad-hoc query on the pinned conn.
With this change the final read reflects the surviving cluster: on the run above it would connect to fc2/fc6, read the full row set, and validate clean.
